### PR TITLE
Recover and merge pre-existing PREACT updates onto updated dev

### DIFF
--- a/PREACT/PREACTcore/Source/Engine/Engine.cs
+++ b/PREACT/PREACTcore/Source/Engine/Engine.cs
@@ -83,7 +83,7 @@ namespace PREACT
                 _ENGINE = this;
             }
 
-            SetupNativeLibraries();                  
+            SetupNativeLibraries();
         }
 
         string _projLibPath, _projDataPath, _sumoPath;
@@ -144,6 +144,15 @@ namespace PREACT
             //OSGeo.GDAL.Gdal.SetConfigOption("PROJ_LIB", projLib); //should not be needed
             //OSGeo.GDAL.Gdal.SetConfigOption("PROJ_DATA", projData);
             OSGeo.OSR.Osr.SetPROJSearchPaths(new string[] { _projLibPath, _projDataPath });
+
+            // Force PROJ to use SUMO's proj.db. Other installs (e.g. Prometheus) can
+            // put an incompatible proj.db on the search path and cause proj_identify to fail.
+            string sumoProj = FindSumoProjDataPath();
+            if (sumoProj != null)
+            {
+                OSGeo.GDAL.Gdal.SetConfigOption("PROJ_DATA", sumoProj);
+            }
+
 
             try
             {
@@ -657,8 +666,27 @@ namespace PREACT
                         }
                     }
                 }
-            }            
-        } 
+            }
+        }
+
+        private static string FindSumoProjDataPath()
+        {
+            // Walk PATH entries looking for sumo.exe, then resolve ../share/proj relative to its bin dir.
+            string pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            foreach (string dir in pathEnv.Split(Path.PathSeparator))
+            {
+                string sumoExe = Path.Combine(dir, "sumo.exe");
+                if (File.Exists(sumoExe))
+                {
+                    string candidate = Path.GetFullPath(Path.Combine(dir, "..", "share", "proj"));
+                    if (File.Exists(Path.Combine(candidate, "proj.db")))
+                    {
+                        return candidate;
+                    }
+                }
+            }
+            return null;
+        }
     }
 }
 

--- a/PREACT/PREACTcore/Source/Evacuation/Pedestrian/Modules/MacroHouseholdSim/MacroHouseholdSim.cs
+++ b/PREACT/PREACTcore/Source/Evacuation/Pedestrian/Modules/MacroHouseholdSim/MacroHouseholdSim.cs
@@ -174,7 +174,7 @@ namespace PREACT.Pedestrian
                 //assume all cars in household goes to the same goal, else we have to make a new call to select goal for every car
                 EvacuationDestination evacDest = _simulation.Evacuation.GetEvacuationDestination(household.GetVehicleLatLon(), household.EvacuationGroup);
 
-                if (evacDest.Blocked)
+                if (evacDest != null && evacDest.Blocked)
                 {
                     _simulation.Evacuation.GetBestAvailableDestination(household.EvacuationGroup, household.GetVehicleLatLon());
                 }

--- a/PREACT/PREACTcore/Source/Input/Categories/SmokeInput/Modules/LagrangianInput.cs
+++ b/PREACT/PREACTcore/Source/Input/Categories/SmokeInput/Modules/LagrangianInput.cs
@@ -35,6 +35,7 @@ namespace PREACT.Input
                 return newInput;
             }
 
+            success = true;
             return newInput;
         }
     }

--- a/PREACT/PREACTcore/Source/Input/PREACTInput.cs
+++ b/PREACT/PREACTcore/Source/Input/PREACTInput.cs
@@ -92,7 +92,7 @@ namespace PREACT.Input
             List<char> chars = new List<char>();
             for(int i = 0; i < input.Length; ++i)
             {
-                if (input[i] != ' ')
+                if (input[i] != ' ' && input[i] != '\t')
                 {
                     chars.Add(input[i]);
                 }

--- a/PREACT/PREACTcore/Source/Simulation/EvacuationManager.cs
+++ b/PREACT/PREACTcore/Source/Simulation/EvacuationManager.cs
@@ -452,7 +452,7 @@ namespace PREACT.Evacuation
             }
             else //default to closest
             {
-                GetClosestEuclideanDestination(latLon);
+                goal = GetClosestEuclideanDestination(latLon);
             }
 
             if (goal == null)

--- a/PREACT/PREACTexecute/PREACTexecute.csproj
+++ b/PREACT/PREACTexecute/PREACTexecute.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release</Configurations>
@@ -13,6 +13,41 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PREACTcore\PREACTcore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\x64\gdal_wrap.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>gdal_wrap.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\x64\gdalconst_wrap.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>gdalconst_wrap.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\x64\ogr_wrap.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>ogr_wrap.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\x64\osr_wrap.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>osr_wrap.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\gdal_csharp.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>gdal_csharp.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\gdalconst_csharp.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>gdalconst_csharp.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\ogr_csharp.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>ogr_csharp.dll</Link>
+    </None>
+    <None Include="..\PREACTcore\ThirdParty\GDAL\osr_csharp.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>osr_csharp.dll</Link>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/PREACT/PREACTexecute/Source/Program.cs
+++ b/PREACT/PREACTexecute/Source/Program.cs
@@ -1,16 +1,32 @@
-﻿namespace PREACT
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace PREACT
 {
     internal class Program
     {
         static void Main(string[] args)
         {
+            // .NET 10 won't automatically probe the app directory for strongly-named
+            // .NET Framework assemblies (e.g. GDAL C# bindings). Resolve them explicitly.
+            AssemblyLoadContext.Default.Resolving += (context, name) =>
+            {
+                string appDir = AppContext.BaseDirectory;
+                string candidate = Path.Combine(appDir, name.Name + ".dll");
+                if (File.Exists(candidate))
+                {
+                    return context.LoadFromAssemblyPath(candidate);
+                }
+                return null;
+            };
+
             PREACTexecute preact = new PREACTexecute();
             preact.Execute(args);
             while (!preact.IsDone)
             {
             }
 
-            Console.WriteLine("Simulation run executed, shutting down.");           
+            Console.WriteLine("Simulation run executed, shutting down.");
         }
     }
 }

--- a/WUInity/Packages/packages-lock.json
+++ b/WUInity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.28",
+      "version": "1.8.29",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -120,7 +120,7 @@
       }
     },
     "com.unity.test-framework.performance": {
-      "version": "3.2.0",
+      "version": "3.4.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Resolved 6 merge conflicts from git stash apply between the dev branch updates and stashed PREACT work
- Unity package/project files (manifest.json, packages-lock.json, ProjectVersion.txt): kept HEAD/remote versions (Unity 6000.3.12f1, ide.visualstudio 2.0.27, inputsystem 1.19.0, render-pipelines.universal 17.3.0)
- PREACTcore.csproj: kept HEADs updated Runtimes/Native/ DLL structure (GDAL, NFDRS4, kPERIL, OpenMeteo) over stashs older ThirdParty/ paths
- Engine.cs: merged both sides - preserved HEADs SetupNativeLibraries() with full cross-platform PATH setup and PROJ search paths, AND integrated the stashs FindSumoProjDataPath() SUMO proj.db override
- Simulation.cs: kept HEADs clean refactored architecture (module creation delegated to manager classes), discarding stashs old inline module-creation methods that referenced nonexistent fields from a prior design

## Test plan

- [x] Build PREACTcore in Release and confirm native DLLs copy to output correctly
- [ ] Run a smoke test simulation to confirm SetupNativeLibraries() works
- [ ] Verify SUMO proj.db override path is found when SUMO is installed
- [ ] Open Unity project in 6000.3.12f1 and confirm packages resolve cleanly
- [ ] Confirm all modified C# files compile without errors